### PR TITLE
Adiciona alias para rebase a partir de origin/<branch>

### DIFF
--- a/Configs/.gitconfig
+++ b/Configs/.gitconfig
@@ -36,6 +36,7 @@
     p = push
     pushsync = push --set-upstream origin HEAD
     fush = push --force-with-lease
+    rbo = !git fetch origin && git rebase origin/$(git symbolic-ref --short HEAD)
 
 [rerere]
     enabled = true


### PR DESCRIPTION
## Summary
- add `rbo` alias to `.gitconfig` for rebasing from the remote branch that matches the current branch name

## Testing
- `git config -f Configs/.gitconfig --get alias.rbo`

------
https://chatgpt.com/codex/tasks/task_e_68404c30309c8323bea351c2f694afd6